### PR TITLE
Corrigindo download-area e tamanho das imagens

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
                 <p class="registrate-p">Não tem uma conta? <a href="#" class="registrate-link">Cadastre-se</a></p>
             </div>
 
-            <div class="download-area">
+            <div class="download-area hidden-download">
                 <p>Obtenha o aplicativo.</p>
                 <div class="download-images">
                     <img src="images/apple.png" class="apple" alt="download através da app store">

--- a/mobile.css
+++ b/mobile.css
@@ -1,3 +1,19 @@
+@media only screen and (min-width: 960px) {
+	.hidden-download {
+		display: none;
+	    }
+}
+@media only screen and (min-width: 1440px) {
+	.hidden-download {
+		display: none;
+	    }
+}
+@media only screen and (min-width: 2000px) {
+	.hidden-download {
+		display: none;
+	    }
+}
+
 @media only screen and (max-width: 992px) {
     .hidden {
         display: none;

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ body {
 
 .yu-feed {
     position: relative;
-    width: 100%;
+    width: 64%;
     height: 600px;
     margin-left: 210px;
 }
@@ -32,7 +32,7 @@ body {
 .dio-post {
     position: absolute;
     height: 600px;
-    width: 40%;
+    width: 32%;
     margin-top: 20px;
     margin-left: 310px;
 
@@ -166,8 +166,7 @@ body {
     display: flex;
     flex-direction: column;
     width: 290px;
-    margin-left: 60px;
-    margin-top: 20px;
+    margin: 20px auto;
     justify-content: center;
 
 }


### PR DESCRIPTION
Corrigindo download area usando `margin: 20px auto` para organizar o conteudo no centro.

Removendo download area do desktop.

Corrigindo tamanho das imagens dos smartphones.